### PR TITLE
Discard master-slave jargon

### DIFF
--- a/ds18b20.py
+++ b/ds18b20.py
@@ -28,7 +28,7 @@ logging.info('load driver w1-therm by modprobe')
 
 # define sensor directory
 base_dir = '/sys/bus/w1/devices/'
-device_file = '/w1_slave'
+device_file = '/w1_subordinate'
 logging.debug('define sensor directory')
 
 # create class Sensor

--- a/handleDs18b20.py
+++ b/handleDs18b20.py
@@ -25,7 +25,7 @@ logging.info('load driver w1-therm by modprobe')
 
 # define sensor directory
 base_dir = '/sys/bus/w1/devices/'
-device_file = '/w1_slave'
+device_file = '/w1_subordinate'
 logging.debug('define sensor directory')
 
 # create class Sensor


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.